### PR TITLE
Redesign site content

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,8 @@
                 <div class="card">
                     <h2 id="page-title">MyUW Web Components</h2>
                     <p>This site was created to allow anyone to see, test, and play with the <a href="https://github.com/myuw-web-components" target="_blank">MyUW Web Components</a> library.</p>
-                    <p>Experiment with the cards below (one for each component) to see how your app might look while using MyUW Web Components. If you want to try using them yourself, scroll down to the <a href="#using-components">Using Components</a> section.</p>
+                    <p>Each list item below represents one of the components used to build this site. Expand each of them to see various things you can customize. Any changes you make will be reflected live on this page.</p>
+                    <p>When you've customized the components with whatever changes you want, scroll down to the <a href="#using-components">Using Components</a> section to generate code you can copy and paste into your own app/web page.</p>
                     <div class="test-content">
                         <!-- TOP BAR INTERACTIVE CONTENT -->
                         <div class="grid-item">

--- a/index.html
+++ b/index.html
@@ -3,19 +3,23 @@
         <!-- Viewport meta tag -->
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <!-- UW-Madison brand fonts -->
-        <link rel="stylesheet" id="uwmadison-fonts-css"  href="https://brand.wisc.edu/content/themes/uw-theme/dist/fonts/uw160/fonts.css?ver=1.2.2" type="text/css" media="all" />
-        
-        <!-- Demo styles -->
-        <link rel="stylesheet" href="./src/styles.css" type="text/css" />
-
-        <!-- Syntax highlighting -->
-        <link href="./src/themes/prism.css" rel="stylesheet" />
-
         <!-- Material Design Lite Library -->
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
         <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
         <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+
+        <!-- UW-Madison brand fonts -->
+        <link rel="stylesheet" id="uwmadison-fonts-css"  href="https://brand.wisc.edu/content/themes/uw-theme/dist/fonts/uw160/fonts.css?ver=1.2.2" type="text/css" media="all" />
+
+        <!-- Syntax highlighting -->
+        <link href="./src/themes/prism.css" rel="stylesheet" />
+
+        <!-- Demo styles -->
+        <link rel="stylesheet" href="./src/styles.css" type="text/css" />
+
+        <!-- <dialog> element polyfill -->
+        <link rel="stylesheet" href="node_modules/dialog-polyfill/dialog-polyfill.css" type="text/css"/>
+        <script src="node_modules/dialog-polyfill/dialog-polyfill.js"></script>
         
         <style>
             body {
@@ -28,9 +32,11 @@
                 --myuw-app-bar-font: 'Verlag';
             }
         </style>
-        <!-- Web component polyfill loader -->
-        <script src="https://cdn.rawgit.com/webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 
+        <!-- Web component polyfill loader -->
+        <script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.1.3/webcomponents-loader.js"></script>
+
+        <!-- myuw-web-components -->
         <script src="https://unpkg.com/@myuw-web-components/myuw-app-styles@^1"></script>
 
         <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-app-bar@^1?module"></script>
@@ -81,218 +87,87 @@
         </myuw-app-bar>
 
         <div class="demo__container" role="main">
-            <section>
+            <section class="section__demos">
                 <div class="card">
-                    <h2 id="page-title">MyUW Web Components</h2>
-                    <p>This site was created to allow anyone to see, test, and play with the <a href="https://github.com/myuw-web-components" target="_blank">MyUW Web Components</a> library.</p>
-                    <p>Each list item below represents one of the components used to build this site. Expand each of them to see various things you can customize. Any changes you make will be reflected live on this page.</p>
-                    <p>When you've customized the components with whatever changes you want, scroll down to the <a href="#using-components">Using Components</a> section to generate code you can copy and paste into your own app/web page.</p>
-                    <div class="test-content">
-                        <!-- TOP BAR INTERACTIVE CONTENT -->
-                        <div class="grid-item">
-                            <h3>Top app bar</h3>
-                            <a class="subtitle" href="https://github.com/myuw-web-components/myuw-app-bar">myuw-app-bar</a>
-                            <div class="interactive">
-                                <form name="topBarDemos">
-                                    <div class="form-control row">
-                                        <input id="themeName" type="text" placeholder="New theme name"/>
-                                        <button onclick="updateTitle(event, 'theme-name',  themeName.value)">Update theme name</button>
-                                    </div>
-                                    <div class="form-control row">
-                                        <input id="appName" type="text" placeholder="New app name"/>
-                                        <button onclick="updateTitle(event, 'app-name',  appName.value)">Update app name</button>
-                                    </div>
-                                    <div class="form-control row">
-                                        <input id="appUrl" type="text" placeholder="https://www.wisc.edu"/>
-                                        <button onclick="updateTitle(event, 'app-url',  appUrl.value)">Update title link</button>
-                                    </div>
-                                    <div class="form-control row">
-                                        <input id="barBackground" type="text" placeholder="rgb(33,150,243)"/>
-                                        <button onclick="updateBarBackground(event, 'myuw-app-bar-bg',  barBackground.value)">Update background color</button>
-                                    </div>
-                                    <div class="form-control">
-                                        <label for="theme">Change the theme:</label>
-                                        <select id="theme" type="text" onchange="updateTheme(theme.value)">
-                                            <option value="">MyUW Red</option>
-                                            <option value="uw-madison-white-theme">MyUW White</option>
-                                        </select>
-                                    </div>
-                                </form>
-                            </div>
-                        </div>
-                        <!-- NAVIGATION DRAWER INTERACTIVE CONTENT -->
-                        <div class="grid-item">
-                            <div class="grid-title row">
-                                <div class="column">
-                                    <h3>Navigation drawer</h3>
-                                    <a class="subtitle" href="https://github.com/myuw-web-components/myuw-drawer">myuw-drawer</a>
-                                </div>
-                                <button id="toggleDrawer" aria-label="Hide navigation drawer" class="icon-button" onclick="toggleComponent('drawer')">
-                                    <i id="drawerIconVisibility" class="material-icons">visibility</i>
-                                </button>
-                                <div id="drawerToggleTooltip" class="mdl-tooltip" data-mdl-for="toggleDrawer">
-                                    Hide drawer
-                                </div>
-                            </div>
-                            <div class="interactive">
-                                <form name="drawerDemos" onsubmit="event.preventDefault(); addDrawerLink()">
-                                    <div class="row">
-                                        <div class="form-control column">
-                                            <label for="navItemLabel">Link text:</label>
-                                            <input id="navItemLabel" required type="text" placeholder="e.g. 'Course Search and Enroll'">
-                                        </div>
-                                        <div class="form-control column">
-                                            <label for="navItemIcon">Material icon&nbsp;
-                                                <a aria-label="see material icons" id="navIconInfo" class="icon-button" href="https://material.io/tools/icons" target="_blank"><i class="material-icons">help</i></a>
-                                            </label>
-                                            <input id="navItemIcon" type="text" placeholder="e.g. 'help'">
-                                        </div>
-                                        <div id="materialIconTooltip" class="mdl-tooltip" data-mdl-for="navIconInfo">
-                                            See available icons
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="form-control column">
-                                            <label for="navItemHref">Link URL:</label>
-                                            <input id="navItemHref" required type="text" placeholder="e.g. 'https://enroll.wisc.edu'">
-                                        </div>
-                                    </div>
-                                    <button aria-label="add navigation link">Add navigation item</button>
-                                    <span id="drawerHelperText" class="helper"></span>
-                                </form>
-                            </div>
-                        </div>
-                        <!-- SEARCH BAR INTERACTIVE CONTENT -->
-                        <div class="grid-item">
-                            <div class="grid-title row">
-                                <div class="column">
-                                    <h3>Search bar</h3>
-                                    <a class="subtitle" href="https://github.com/myuw-web-components/myuw-search">myuw-search</a>
-                                </div>
-                                <button id="toggleSearch" aria-label="Hide search bar component" class="icon-button" onclick="toggleComponent('search')">
-                                    <i id="searchIconVisibility" class="material-icons">visibility</i>
-                                </button>
-                                <div id="searchToggleTooltip" class="mdl-tooltip" data-mdl-for="toggleSearch">
-                                    Hide search
-                                </div>
-                            </div>
-                            <div class="interactive">
-                                <form name="profileDemos" onsubmit="event.preventDefault();updateSearchBar();">
-                                    <div class="row">
-                                        <div class="form-control column">
-                                            <label for="searchPlaceholder">Search box placeholder:</label> 
-                                            <input id="searchPlaceholder" type="text" placeholder="Search MyUW">
-                                        </div>
-                                        <div class="form-control column">
-                                            <label for="searchAriaLabel">Search button aria-label:</label>
-                                            <input id="searchAriaLabel" type="text" placeholder="Submit MyUW search">
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="form-control column">
-                                            <label for="searchIcon">
-                                                Material icon&nbsp;
-                                                <a aria-label="see material icons" id="searchIconInfo" class="icon-button" href="https://material.io/tools/icons" target="_blank"><i class="material-icons">help</i></a>
-                                            </label>
-                                            <div id="materialIconTooltip" class="mdl-tooltip" data-mdl-for="searchIconInfo">
-                                                See available icons
-                                            </div>
-                                            <input id="searchIcon" type="text" placeholder="search">
-                                        </div>
-                                    </div>
-                                    <button>Update search component</button>
-                                </form>
-                                <h4>Search callback function</h4>
-                                <div class="form-control row">
-                                    <label for="searchCallback">Choose search behavior: </label>
-                                    <select id="searchCallback" onchange="updateCallback(searchCallback.value)">
-                                        <option value="alert">Generate an alert</option>
-                                        <option value="yahoo">Change some text on screen</option>
-                                    </select>
-                                </div>
-                                <p>
-                                    The search component allows you to set a "callback" value on the root element. The example code below demonstrates how this page handles searches:
-                                </p>
-                                <pre class="language-js"><code id="searchCallbackCode"></code></pre>
-                            </div>
-                        </div>
-                        <!-- PROFILE BUTTON INTERACTIVE CONTENT -->
-                        <div class="grid-item">
-                            <div class="grid-title row">
-                                <div class="column">
-                                    <h3>Profile button/menu</h3>
-                                    <a class="subtitle" href="https://github.com/myuw-web-components/myuw-profile">myuw-profile</a>
-                                </div>
-                                <button id="toggleProfile" aria-label="Hide profile menu component" class="icon-button" onclick="toggleComponent('profile')">
-                                    <i id="profileIconVisibility" class="material-icons">visibility</i>
-                                </button>
-                                <div id="profileToggleTooltip" class="mdl-tooltip" data-mdl-for="toggleProfile">
-                                    Hide profile
-                                </div>                                
-                            </div>
-                            <div class="interactive">
-                                <form name="profileDemos" onsubmit="event.preventDefault(); updateProfileTemplate()">
-                                    <div class="row">
-                                        <div class="form-control column">
-                                            <label for="profileColor">Profile button color: </label>
-                                            <input id="profileColor" type="text" placeholder="#888">
-                                        </div>
-                                        <button aria-label="set profile button color" onclick="setProfileColor(event, profileColor.value)" type="button">Set profile color</button>
-                                    </div>
-                                    <div class="form-control column">
-                                        <div class="row">
-                                            <label for="sessionStates">Session states:</label>
-                                        </div>
-                                        <div class="row" id="sessionStates">
-                                            <button aria-label="set no session" onclick="setSession('jargon')" type="button">No session</button>&nbsp;&nbsp;
-                                            <button aria-label="set alternate session" onclick="setSession('/demo/session2.json')" type="button">Swap session</button>&nbsp;&nbsp;
-                                            <button aria-label="restore demo session" onclick="setSession('/demo/session.json')" type="button">Restore demo session</button>
-                                        </div>
-                                    </div>
-                                    <h4>Other configurable fields</h4>
-                                    <div class="row">
-                                        <div class="form-control column">
-                                            <label for="loginUrl">Login URL:</label>
-                                            <input id="loginUrl" type="text" placeholder="Enter login url">
-                                        </div>
-                                        <div class="form-control column">
-                                            <label for="logoutUrl">Logout URL:</label>
-                                            <input id="logoutUrl" type="text" placeholder="Enter logout url">
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="form-control column">
-                                            <label for="sessionEndpoint">Session endpoint:</label>
-                                            <input id="sessionEndpoint" type="text" placeholder="/demo/session2.json">
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="form-control column">
-                                            <label for="profileLinkLabel">Menu link text:</label>
-                                            <input id="profileLinkLabel" type="text" placeholder="Google">
-                                        </div>
-                                        <div class="form-control column">
-                                            <label for="profileLinkUrl">Menu link url:</label>
-                                            <input id="profileLinkUrl" type="text" placeholder="www.google.com">
-                                        </div>
-                                    </div>
-                                    <button aria-label="update profile component">Update profile template</button>
-                                    <span id="profileHelperText" class="helper"></span>
-                                </form>
-                            </div>
+                    <div class="title row">
+                        <h2 id="page-title">MyUW Web Components</h2>
+                        <button id="toggleTheme" class="mdl-button mdl-js-button mdl-button--raised mdl-button--icon" onclick="toggleTheme()">
+                            <i class="material-icons">style</i>
+                        </button>
+                        <div class="mdl-tooltip" data-mdl-for="toggleTheme">
+                            Try <span id="alternateThemeName">MyUW White</span> theme
                         </div>
                     </div>
+                    <p>This site was created to allow anyone to see, test, and play with the <a href="https://github.com/myuw-web-components" target="_blank">MyUW Web Components</a> library. Each list item below represents one of the components used to build this site.</p>
+                    <table class="mdl-data-table mdl-js-data-table">
+                        <thead>
+                            <tr>
+                                <th class="mdl-data-table__cell--non-numeric">Component</th>
+                                <th>Github link</th>
+                                <th>Toggle visibility</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr onclick="showDialog('topBarDialog')">
+                                <td class="mdl-data-table__cell--non-numeric">Top app bar</td>
+                                <td><a href="https://github.com/myuw-web-components/myuw-app-bar" target="_blank" onclick="event.stopImmediatePropagation()">myuw-app-bar</a></td>
+                                <td>n/a</td>
+                            </tr>
+                            <tr onclick="showDialog('drawerDialog')">
+                                <td class="mdl-data-table__cell--non-numeric">Navigation drawer</td>
+                                <td><a href="https://github.com/myuw-web-components/myuw-drawer" target="_blank" onclick="event.stopImmediatePropagation()">myuw-drawer</a></td>
+                                <td>
+                                    <button aria-label="Hide navigation drawer" class="icon-button" onclick="event.stopPropagation();toggleComponent('drawer')">
+                                        <i id="drawerIconVisibilityTable" class="material-icons">visibility</i>
+                                    </button>
+                                </td>
+                            </tr>
+                            <tr onclick="showDialog('searchDialog')">
+                                <td class="mdl-data-table__cell--non-numeric">Search bar</td>
+                                <td><a href="https://github.com/myuw-web-components/myuw-search" target="_blank" onclick="event.stopImmediatePropagation()">myuw-search</a></td>
+                                <td>
+                                    <button aria-label="Hide navigation drawer" class="icon-button" onclick="event.stopPropagation();toggleComponent('search')">
+                                        <i id="searchIconVisibilityTable" class="material-icons">visibility</i>
+                                    </button>
+                                </td>
+                            </tr>
+                            <tr onclick="showDialog('profileDialog')">
+                                <td class="mdl-data-table__cell--non-numeric">Profile button</td>
+                                <td><a href="https://github.com/myuw-web-components/myuw-profile" target="_blank" onclick="event.stopImmediatePropagation()">myuw-profile</a></td>
+                                <td>
+                                    <button aria-label="Hide navigation drawer" class="icon-button" onclick="event.stopPropagation();toggleComponent('profile')">
+                                        <i id="profileIconVisibilityTable" class="material-icons">visibility</i>
+                                    </button>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="mdl-data-table__cell--non-numeric">Help and feedback (WIP)</td>
+                                <td><a href="https://github.com/myuw-web-components/myuw-help" target="_blank" onclick="event.stopImmediatePropagation()">myuw-help</a></td>
+                                <td>n/a</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <h3>How to use this site</h3>
+                    <ol>
+                        <li>Click a component's name in the table above</li>
+                        <li>Use the dialog that opens to customize the component however you like. <strong>Any changes you make will be reflected live on this page.</strong></li>
+                        <li>When you've customized the page to your liking, scroll down to the "<a href="#get-components">Get components</a>" section where you can generate the code for your custom components that you can copy and paste into your own app/web page.</li>
+                    </ol>
                 </div>
             </section>
             <!-- Brief about section / mission statement -->
             <section class="section__usage">
                 <div class="card">
-                    <h2 id="using-components">Using Components</h2>
+                    <h2 id="get-components">Get components</h2>
                     <p>
                         You can use this tool to generate all the HTML you'll need to use MyUW Web Components in your project. 
                         The markup generated will reflect any configuration options you have changed (or left unchanged) while experimenting with the demos.
                     </p>
-                    <button onclick="generateComponentMarkup()">Generate HTML code</button>
+                    <p><strong>Please note:</strong> The markup generated by this tool includes the <i>latest</i> version of every component 
+                        by default (the same ones used on the site). We recommend looking at the CHANGELOG.md file in each component's 
+                        repository to select a specific, stable version that suits your needs. These components are subject to periods of 
+                        rapid development and the latest versions are not guaranteed to be 100% stable.</p>
+                    <button class="mdl-button mdl-js-button mdl-button--raised" onclick="generateComponentMarkup()">Generate HTML code</button>
                     <ol>
                         <li>
                             Import components and dependencies into your document 
@@ -331,8 +206,209 @@
                 </div>
             </section>
         </div>
+
+        <!-- 
+            Dialogs for interactive content 
+        -->
+        <!-- TOP BAR DIALOG -->
+        <dialog class="mdl-dialog" id="topBarDialog">
+            <div class="dialog-title row">
+                <h4>Top app bar</h4>
+                <button id="closeBarDialog" type="button" class="icon-button close"><i class="material-icons">close</i></button>
+                <div id="closeBarTooltip" class="mdl-tooltip" data-mdl-for="closeBarDialog">
+                    Close app bar dialog
+                </div>  
+            </div>
+            <div class="mdl-dialog__content interactive">
+                <form name="topBarDemos">
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="themeName" >
+                        <label class="mdl-textfield__label" for="themeName">Theme name</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="appName" >
+                        <label class="mdl-textfield__label" for="appName">App name</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="appUrl" >
+                        <label class="mdl-textfield__label" for="appUrl">Title link</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="barBackground">
+                        <label class="mdl-textfield__label" for="barBackground">Background color</label>
+                        <div id="barBackgroundTooltip" class="mdl-tooltip" data-mdl-for="barBackground">
+                            Accepts hex value, rgb, rgba, or plain text color
+                        </div>
+                    </div>
+                </form>
+                <div class="mdl-dialog__actions">
+                    <button type="button" class="mdl-button md-js-button mdl-button--raised" onclick="updateTopAppBar(event)">Update top bar</button>
+                </div>
+            </div>
+        </dialog>
+
+        <!-- NAVIGATION DRAWER DIALOG -->
+        <dialog class="mdl-dialog" id="drawerDialog">
+            <div class="dialog-title row">
+                <h4>Navigation drawer</h4>
+                <div class="dialog-title-controls row">
+                    <button id="toggleDrawer" aria-label="Hide navigation drawer" class="icon-button" onclick="toggleComponent('drawer')">
+                        <i id="drawerIconVisibility" class="material-icons">visibility</i>
+                    </button>
+                    <div id="drawerToggleTooltip" class="mdl-tooltip" data-mdl-for="toggleDrawer">
+                        Hide drawer
+                    </div>
+                    <button id="closeDrawerDialog" type="button" class="icon-button close"><i class="material-icons">close</i></button>
+                    <div id="closeDrawerTooltip" class="mdl-tooltip" data-mdl-for="closeDrawerDialog">
+                        Close drawer dialog
+                    </div>  
+                </div>
+            </div>
+            <div class="mdl-dialog__content interactive">
+                <form name="drawerDemos" onsubmit="event.preventDefault(); addDrawerLink()">
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="navItemLabel" required>
+                        <label class="mdl-textfield__label" for="navItemLabel">Link text</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="navItemHref" required>
+                        <label class="mdl-textfield__label" for="navItemHref">Link URL:</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="navItemIcon">
+                        <label class="mdl-textfield__label" for="navItemIcon">Material icon</label>
+                    </div>
+                    <a aria-label="see material icons" id="navIconInfo" class="icon-button" href="https://material.io/tools/icons" target="_blank"><i class="material-icons">help</i></a>
+                    <div id="materialIconTooltip" class="mdl-tooltip" data-mdl-for="navIconInfo">
+                        See available icons
+                    </div>
+                    <div class="mdl-dialog__actions">
+                        <button type="submit" class="mdl-button md-js-button mdl-button--raised">Add navigation link</button>
+                        <span id="drawerHelperText" class="helper"></span>
+                    </div>
+                </form>
+            </div>
+        </dialog>
+
+        <!-- SEARCH BAR DIALOG -->
+        <dialog class="mdl-dialog" id="searchDialog">
+            <div class="dialog-title row">
+                <h4>Search bar</h4>
+                <div class="dialog-title-controls row">
+                    <button id="toggleSearch" aria-label="Hide search bar component" class="icon-button" onclick="toggleComponent('search')">
+                        <i id="searchIconVisibility" class="material-icons">visibility</i>
+                    </button>
+                    <div id="searchToggleTooltip" class="mdl-tooltip" data-mdl-for="toggleSearch">
+                        Hide search
+                    </div>
+                    <button id="closeSearchDialog" type="button" class="icon-button close"><i class="material-icons">close</i></button>
+                    <div id="closeSearchTooltip" class="mdl-tooltip" data-mdl-for="closeSearchDialog">
+                        Close search dialog
+                    </div>                   
+                </div>
+            </div>
+            <div class="mdl-dialog__content interactive">
+                <form name="profileDemos" onsubmit="event.preventDefault();updateSearchBar();">
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="searchPlaceholder">
+                        <label class="mdl-textfield__label" for="searchPlaceholder">Search box placeholder</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="searchAriaLabel">
+                        <label class="mdl-textfield__label" for="searchAriaLabel">Search button aria-label</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="searchIcon">
+                        <label class="mdl-textfield__label" for="searchIcon">Material icon</label>
+                    </div>
+                    <a aria-label="see material icons" id="searchIconInfo" class="icon-button" href="https://material.io/tools/icons" target="_blank"><i class="material-icons">help</i></a>
+                    <div id="materialIconTooltip" class="mdl-tooltip" data-mdl-for="searchIconInfo">
+                        See available icons
+                    </div>
+                    <div class="form-control">
+                            <label for="searchCallback">Choose search behavior: </label>
+                            <select id="searchCallback" onchange="updateCallback(searchCallback.value)">
+                                <option value="alert">Generate an alert</option>
+                                <option value="yahoo">Change some text on screen</option>
+                            </select>
+                        </div>
+                    <div class="mdl-dialog__actions">
+                        <button type="submit" class="mdl-button md-js-button mdl-button--raised">Update search component</button>
+                    </div>
+                </form>
+                <h5>Guidance: Search behavior</h5>
+                <p>
+                    The search component allows you to set a "callback" value on the root element. It is up to write the corresponding function in your code. Without it, the search bar won't do anything when a search is submitted. 
+                    The example code below demonstrates how this page handles searches:
+                </p>
+                <pre class="language-js"><code id="searchCallbackCode"></code></pre>
+            </div>
+        </dialog>
+
+        <!-- PROFILE BUTTON INTERACTIVE CONTENT -->
+        <dialog class="mdl-dialog" id="profileDialog">
+            <div class="dialog-title row">
+                <h4>Profile button/menu</h4>
+                <div class="dialog-title-controls row">
+                    <button id="toggleProfile" aria-label="Hide profile menu component" class="icon-button" onclick="toggleComponent('profile')">
+                        <i id="profileIconVisibility" class="material-icons">visibility</i>
+                    </button>
+                    <div id="profileToggleTooltip" class="mdl-tooltip" data-mdl-for="toggleProfile">
+                        Hide profile
+                    </div>
+                    <button id="closeProfileDialog" type="button" class="icon-button close"><i class="material-icons">close</i></button>    
+                    <div id="closeProfileTooltip" class="mdl-tooltip" data-mdl-for="closeProfileDialog">
+                        Close profile dialog
+                    </div>                   
+                </div>
+            </div>
+            <div class="mdl-dialog__content interactive">
+                <form name="profileDemos" onsubmit="event.preventDefault(); updateProfileTemplate()">
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="profileColor">
+                        <label class="mdl-textfield__label" for="profileColor">Profile button color</label>
+                    </div>
+                    <div id="profileColorTooltip" class="mdl-tooltip" data-mdl-for="profileColor">
+                        Accepts hex value, rgb, rgba, or plain text color
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="loginUrl">
+                        <label class="mdl-textfield__label" for="loginUrl">Login URL</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="logoutUrl">
+                        <label class="mdl-textfield__label" for="logoutUrl">Logout URL</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="sessionEndpoint" placeholder="/demo/session2.json">
+                        <label class="mdl-textfield__label" for="sessionEndpoint">Session endpoint</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="profileLinkLabel">
+                        <label class="mdl-textfield__label" for="profileLinkLabel">Menu link text</label>
+                    </div>
+                    <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+                        <input class="mdl-textfield__input" type="text" id="profileLinkUrl">
+                        <label class="mdl-textfield__label" for="profileLinkUrl">Menu link url</label>
+                    </div>
+                    <div class="mdl-dialog__actions">
+                        <button class="mdl-button md-js-button mdl-button--raised">Update profile component</button>
+                        <span id="profileHelperText" class="helper"></span>
+                    </div>
+                </form>
+                <h5>Example session states</h5>
+                <p>These buttons alter the "session-endpoint" attribute of the profile component. The component displays a different appearance depending on the JSON available at the provided endpoint.</p>
+                <div class="row" id="sessionStates">
+                    <button aria-label="set no session" class="mdl-button md-js-button" onclick="setSession('jargon')" type="button">No session</button>&nbsp;&nbsp;
+                    <button aria-label="set alternate session" class="mdl-button md-js-button" onclick="setSession('/demo/session2.json')" type="button">Swap session</button>&nbsp;&nbsp;
+                    <button aria-label="restore demo session" class="mdl-button md-js-button" onclick="setSession('/demo/session.json')" type="button">Restore demo session</button>
+                </div>
+            </div>
+        </dialog>
+
         <!-- Demo interactions -->
         <script src='./src/interactions.js'></script>
+        <script src='./src/dialogs.js'></script>
         <!-- Syntax highlighting -->
         <script src="./src/themes/prism.js" data-manual></script>
     </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,6 +206,11 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "dialog-polyfill": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.4.10.tgz",
+      "integrity": "sha512-j5yGMkP8T00UFgyO+78OxiN5vC5dzRQF3BEio+LhNvDbyfxWBsi3sfPArDm54VloaJwy2hm3erEiDWqHRC8rzw=="
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "homepage": "https://github.com/myuw-web-components/myuw-web-components.github.io#readme",
   "devDependencies": {
     "live-server": "^1.2.0"
+  },
+  "dependencies": {
+    "dialog-polyfill": "^0.4.10"
   }
 }

--- a/src/dialogs.js
+++ b/src/dialogs.js
@@ -1,0 +1,14 @@
+function showDialog(id) {
+    var dialog = document.getElementById(id);
+    
+    // Register dialog if polyfill needed
+    if (!dialog.showModal) {
+        dialogPolyfill.registerDialog(dialog);
+    }
+    
+    dialog.showModal();
+      
+    dialog.querySelector('.close').addEventListener('click', function() {
+        dialog.close();
+    });
+}

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -226,11 +226,13 @@ function toggleComponent(componentId) {
         document.getElementById(componentId).hidden = true;
         document.getElementById(componentId + 'IconVisibility').innerText = 'visibility_off';
         document.getElementById(componentId + 'ToggleTooltip').innerText = 'Show ' + componentId;
+        // Remove hidden component from "included" array for code generation
         this.includedComponents.splice(this.includedComponents.indexOf(componentId), 1);
     } else {
         document.getElementById(componentId).hidden = false;
         document.getElementById(componentId + 'IconVisibility').innerText = 'visibility';
         document.getElementById(componentId + 'ToggleTooltip').innerText = 'Hide ' + componentId;
+        // Add component to "included" array for code generation
         this.includedComponents.push(componentId);
     }
 }
@@ -276,15 +278,22 @@ ${searchImport}
 ${profileImport}
     `;
     
-    // Build component template string
-    var templateString = `${this.appBarTemplateStart}
-    ${this.drawerTemplateStart}
-        ${this.drawerLinkTemplate}
-    ${this.drawerTemplateEnd}
-    ${this.searchTemplate}
-    ${this.profileTemplate}
-${this.appBarTemplateEnd}
-    `;
+    // Build component template string, including only markup for visible components
+    var templateString = `${this.appBarTemplateStart}`;
+
+    if (this.includedComponents.indexOf('drawer') != -1) {
+        templateString += `\n\t${this.drawerTemplateStart}\n\t\t${this.drawerLinkTemplate}\n\t${this.drawerTemplateEnd}`;
+    }
+
+    if (this.includedComponents.indexOf('search') != -1) {
+        templateString += `\n\t${this.searchTemplate}`;
+    }
+
+    if (this.includedComponents.indexOf('profile') != -1) {
+        templateString += `\n\t${this.profileTemplate}`;
+    }
+    
+    templateString += `\n${this.appBarTemplateEnd}`;
 
     // Update DOM and call syntax highlighter
     importsContainer.innerHTML = importsString;

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -38,41 +38,56 @@ this.profileTemplate = `&lt;myuw-profile
 
 this.customCssTemplate = `&#47;&#42; You didn't change any theme colors &#42;&#47;`;
 
-
+/*
+    THEME DEMO
+*/
+function toggleTheme() {
+    var themeTooltip = document.getElementById('alternateThemeName');
+    if (document.body.classList.contains('uw-madison-white-theme')) {
+        document.body.classList.remove('uw-madison-white-theme');
+        themeTooltip.innerText = 'MyUW White';
+    } else {
+        document.body.classList.add('uw-madison-white-theme');
+        themeTooltip.innerText = 'MyUW Red';
+    }
+}
 /*
     TOP BAR DEMO FUNCTIONS
 */
-function updateTitle(e, attribute, newValue) {
+function updateTopAppBar(e) {
     e.preventDefault();
+
     // Get app bar
     var _appBar = document.getElementsByTagName('myuw-app-bar')[0];
-    // Update attribute
-    _appBar.setAttribute(attribute, newValue);
-
+    
     // Get property fields
     var themeText = document.getElementById('themeName');
     var appText = document.getElementById('appName');
     var appUrl = document.getElementById('appUrl');
+    var barBackground = document.getElementById('barBackground');
+    
+    // Update attributes
+    _appBar.setAttribute('theme-name', themeText.value);
+    _appBar.setAttribute('app-name', appText.value);
+    _appBar.setAttribute('app-url', appUrl.value);
 
     // Update template for code generation
     this.appBarTemplateStart = `&lt;myuw-app-bar
     theme-name="${themeName.value}"
     app-name="${appName.value}" 
     app-url="${appUrl.value}"&gt;`;
-}
-function updateBarBackground(e, property, value) {
-    e.preventDefault();
-    this.customCssTemplate = `
+
+    // If value was entered for background, create and use custom css template
+    if (barBackground.value.length > 0) {
+        this.customCssTemplate = `
 myuw-app-bar {
-    --${property}: ${value};
+    --myuw-primary-bg: ${barBackground.value};
 }
     `;
     var newCss = document.createElement('style');
     newCss.innerHTML = this.customCssTemplate;
     document.head.appendChild(newCss);
-}
-function updateTheme(theme) {
-    document.body.className = theme;
+    }
 }
 /*
     NAV DRAWER DEMO FUNCTIONS
@@ -163,13 +178,6 @@ function updateCallback(value) {
 /*
     PROFILE DEMO FUNCTIONS
 */
-function setProfileColor(e, newColor) {
-    if (newColor.indexOf('#') < 0) {
-        newColor = '#' + newColor;
-    }
-    document.getElementsByTagName('myuw-profile')[0].setAttribute('background-color', newColor);
-}
-
 function setSession(session) {
     // Remove profile from DOM
     document.getElementsByTagName('myuw-profile')[0].remove();
@@ -205,11 +213,14 @@ function updateProfileTemplate() {
         slot="myuw-profile"
         session-endpoint="${session.value}"
         login-url="${login.value}"
-        logout-url="${logout.value}"&gt;
-        &lt;a href="${linkUrl.value}" slot="nav-item"&gt;${linkText.value}&lt;/a&gt;
-    &lt;/myuw-profile&gt;`;
-    
-    // TODO: Print template to page for copy+paste
+        logout-url="${logout.value}"`;
+
+    if (color.value.length > 0) {
+        document.getElementsByTagName('myuw-profile')[0].setAttribute('background-color', color.value);
+        this.profileTemplate += `\n\t\tbackground-color="${color.value}"`;
+    }
+
+    this.profileTemplate += `&gt;\n\t\t&lt;a href="${linkUrl.value}" slot="nav-item"&gt;${linkText.value}&lt;/a&gt;\n\t&lt;/myuw-profile&gt;`;
 
     // Clear fields and update helper text
     login.value = "";
@@ -225,12 +236,14 @@ function toggleComponent(componentId) {
     if (this.includedComponents.indexOf(componentId) != -1) {
         document.getElementById(componentId).hidden = true;
         document.getElementById(componentId + 'IconVisibility').innerText = 'visibility_off';
+        document.getElementById(componentId + 'IconVisibilityTable').innerText = 'visibility_off';
         document.getElementById(componentId + 'ToggleTooltip').innerText = 'Show ' + componentId;
         // Remove hidden component from "included" array for code generation
         this.includedComponents.splice(this.includedComponents.indexOf(componentId), 1);
     } else {
         document.getElementById(componentId).hidden = false;
         document.getElementById(componentId + 'IconVisibility').innerText = 'visibility';
+        document.getElementById(componentId + 'IconVisibilityTable').innerText = 'visibility';
         document.getElementById(componentId + 'ToggleTooltip').innerText = 'Hide ' + componentId;
         // Add component to "included" array for code generation
         this.includedComponents.push(componentId);
@@ -266,7 +279,7 @@ function generateComponentMarkup() {
 &lt;meta name="viewport" content="width=device-width, initial-scale=1"&gt;
 
 &lt;!-- Web component polyfill loader (required for cross-browser support) --&gt;
-&lt;script src="https://cdn.rawgit.com/webcomponents/webcomponentsjs/webcomponents-bundle.js"&gt;&lt;/script&gt;
+&lt;script src="https://unpkg.com/@webcomponents/webcomponentsjs@2.1.3/webcomponents-loader.js"&gt;&lt;/script&gt;
 
 &lt!-- UW-Madison app styles (recommended if you're a UW-Madison adopter) --&gt;
 &lt;script type="module" src="https://unpkg.com/@myuw-web-components/myuw-app-styles@^1?module"&gt;&lt;/script&gt;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,13 @@ body {
     margin: 0;
     background: #ccc;
 }
+p {
+    font-size: 16px;
+}
+a {
+    color: inherit;
+    font-weight: inherit;
+}
 /* TODO: Update more components to use variables that can be set in theme component (like search field colors/borders) */
 .uw-madison-white-theme .card button {
     font-weight: 500;
@@ -20,6 +27,10 @@ body {
     align-items: center;
 }
 
+.title.row {
+    justify-content: space-between;
+}
+
 .column {
     display: flex;
     flex-direction: column;
@@ -31,43 +42,61 @@ body {
     margin: 0 8px;
 }
 
+.mdl-data-table {
+    width: 100%;
+    font-size: 16px;
+}
+
+.mdl-data-table tr {
+    cursor: pointer;
+}
+
 section {
-    width: 85%;
+    width: 100%;
     margin: 0 auto;
 }
 
 .demo__container ol {
-    padding-left: 0;
+    font-size: 16px;
 }
 
-.demo__container li {
+.section__demos li {
+    margin-bottom: 12px;
+}
+
+.section__usage li {
     font-size: 18px;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    align-items: center;
 }
 
 div.demo__container {
     margin: 18px 36px;
 }
-.demo__container button {
-    min-width: 48px;
-    min-height: 24px;
-    max-height: 36px;
-    padding: 8px 8px;
-    font-size: 14px;
-    overflow-y: hidden;
-    border-radius: 5px;
-    transition: background 0.15s ease-in-out;
+.demo__container button.mdl-button,
+dialog button.mdl-button {
+    text-transform: none;
+    background: transparent;
+    color: var(--myuw-accent-bg);
+}
+.demo__container button.mdl-button.mdl-button--raised,
+dialog button.mdl-button.mdl-button--raised {
+    text-transform: none;
     background: var(--myuw-accent-bg);
     color: var(--myuw-accent-color);
-    outline: none;
 }
-.demo__container button:hover {
+.demo__container button.mdl-button.mdl-button--fab {
+    background: var(--myuw-accent-bg);
+    color: var(--myuw-accent-color);
+}
+dialog button.mdl-button.mdl-button--raised:hover,
+dialog button.mdl-button.mdl-button--raised:focus:not(:active) {
     background: #046085;
-    cursor: pointer;
 }
-.demo__container button.icon-button {
+.demo__container button.icon-button,
+dialog button.icon-button {
     color: #046085;
     background: transparent;
     border-radius: 50%;
@@ -75,15 +104,20 @@ div.demo__container {
     max-height: 48px;
     width: 48px;
     border: none;
+    outline: none;
+    cursor: pointer;
 }
-.demo__container button.icon-button:hover {
+.demo__container button.icon-button:hover,
+dialog button.icon-button:hover {
     background: rgba(0,0,0,0.12);
 }
-.test-content {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-content: flex-start;
+dialog button.icon-button:focus {
+    outline: none;
+}
+.mdl-button--icon {
+    height: 42px;
+    width: 42px;
+    min-width: 42px;
 }
 .card {
     padding: 16px 36px;
@@ -96,74 +130,66 @@ div.demo__container {
     border-radius: 5px;
     margin-bottom: 24px;
 }
-.card .interactive {
-    margin-top: 26px;
-    width: 100%;
-}
 .card code.prettyprint {
     overflow-x: scroll;
     padding: 1rem;
     font-size: 14px;
 }
-.card .form-control {
+.interactive .form-control {
     margin-bottom: 20px;
 }
-.card .form-control.row {
+.interactive .form-control.row {
     justify-content: space-between;
 }
-.card .form-control.column {
+.interactive .form-control.column {
     flex: auto;
     align-content: center;
 }
-.card .subtitle {
-    display: block;
-}
-.card label {
-    font-size: 16px;
-    margin-bottom: 8px;
-    display: flex;
-    align-items: center;
-    align-content: center;
-    line-height: 24px;
-}
-.card .form-control.row label {
-    margin-bottom: 0;
-}
-.card .form-control.column input {
+.interactive .form-control.column input {
     margin-bottom: 8px;
 }
-.card input {
-    height: 36px;
-    border-radius: 5px;
-    margin-right: 8px;
-    font-size: 16px;
-    border: 1px rgb(196, 196, 196) solid;
-    padding: 0 12px;
-    flex: auto;
-}
-.card select {
+.interactive select {
     height: 36px;
     font-size: 16px;
 }
-.grid-item {
-    margin: 0.8rem 0;
-    padding: 0 1.6rem;
-    flex: auto;
-    border: #ccc solid 1px;
-    min-width: 400px;
-    background: rgba(0,0,0,0.02);
-}
-.grid-title {
+.dialog-title {
     width: 100%;
     justify-content: space-between;
     align-content: center;
     align-items: center;
 }
-.grid-item h3 {
+.dialog-item h3 {
     font-size: 24px;
     margin-bottom: 8px;
 }
+dialog.mdl-dialog {
+    width: 100%;
+    border-radius: 3px;
+}
+dialog .mdl-textfield {
+    margin-right: 12px;
+}
+dialog h4 {
+    margin-bottom: 0;
+}
+.mdl-dialog__actions {
+    align-items: center;
+}
+.mdl-dialog__actions>* {
+    height: auto;
+}
+@media (min-width: 600px) {
+    dialog.mdl-dialog {
+        width: 80%;
+    }
+    section {
+        width: 85%;
+    }
+}
 @media (min-width: 1260px) {
+    dialog.mdl-dialog {
+        width: 60%;
+    }
     .grid-item {
         flex: 1 1 45%;
         max-width: 45%;


### PR DESCRIPTION
**In this PR:**
- Use table display with modals for component customization
- Implement more material-design-lite elements for page content
- Don't generate code for hidden components
- Move theme selector outside top bar customization, since it isn't actually part of the top bar component
- Various other improvements to overall look & feel