### PR TITLE
Clarify and extend contact info

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -116,6 +116,26 @@
                     <div class="list-container">
                         <ul class="mdl-list list-contacts">
                             <li class="mdl-list__item mdl-list__item--three-line">
+                                <a class="mdl-list__item-primary-content"
+                                  href="https://groups.google.com/forum/#!forum/myuw-developers"
+                                  target="_blank" rel="noopener noreferrer">
+                                    <img class="mdl-list__item-avatar"
+                                      src="https://github.com/uw-madison-doit.png?size=200">
+                                    <span>MyUW Developers Google Group</span>
+                                    <span class="mdl-list__item-text-body">
+                                        Public, open forum for discussion of all
+                                        things MyUW, including MyUW web
+                                        components.
+                                    </span>
+                                </a>
+                                <span class="mdl-list__item-secondary-content">
+                                    <a class="mdl-list__item-secondary-action"
+                                      href="https://groups.google.com/forum/#!forum/myuw-developers"
+                                      target="_blank" rel="noopener noreferrer">
+                                      <i class="material-icons">web</i></a>
+                                </span>
+                            </li>
+                            <li class="mdl-list__item mdl-list__item--three-line">
                                 <a class="mdl-list__item-primary-content" href="https://github.com/thevoiceofzeke" target="_blank">
                                     <img class="mdl-list__item-avatar" src="https://github.com/thevoiceofzeke.png?size=200">
                                     <span>Zeke Witter</span>

--- a/contacts.html
+++ b/contacts.html
@@ -19,7 +19,7 @@
         <!-- <dialog> element polyfill -->
         <link rel="stylesheet" href="https://unpkg.com/dialog-polyfill@0.4.10/dialog-polyfill.css" type="text/css"/>
         <script src="https://unpkg.com/dialog-polyfill@0.4.10/dialog-polyfill.js"></script>
-        
+
         <style>
             body {
                 padding: 0;
@@ -46,7 +46,7 @@
 
         <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-search@^1?module"></script>
         <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-search@^1"></script>
-        
+
         <script type="module" src="https://unpkg.com/@myuw-web-components/myuw-profile@^1?module"></script>
         <script nomodule src="https://unpkg.com/@myuw-web-components/myuw-profile@^1"></script>
 
@@ -57,9 +57,9 @@
         <myuw-app-bar
             role="toolbar"
             theme-name="MyUW"
-            app-name="Web Components" 
+            app-name="Web Components"
             app-url="/">
-            <myuw-drawer id="drawer" 
+            <myuw-drawer id="drawer"
                 slot="myuw-navigation">
                 <myuw-drawer-link
                   slot="myuw-drawer-links"

--- a/contacts.html
+++ b/contacts.html
@@ -148,6 +148,19 @@
                                 </span>
                             </li>
                             <li class="mdl-list__item mdl-list__item--three-line">
+                                <a class="mdl-list__item-primary-content" href="https://it.wisc.edu/staff/stratman-durrer-annette/" target="_blank">
+                                    <img class="mdl-list__item-avatar" src="https://github.com/uw-madison-doit.png?size=200">
+                                    <span>Annette Statman-Durrer</span>
+                                    <span class="mdl-list__item-text-body">
+                                        MyUW Service Team Lead. (UW-Madison DoIT - EIS - Web Platforms / Services - MyUW)
+                                    </span>
+                                </a>
+                                <span class="mdl-list__item-secondary-content">
+                                    <a class="mdl-list__item-secondary-action" href="mailto:annette.stratmandurrer@wisc.edu">
+                                      <i class="material-icons">email</i></a>
+                                </span>
+                            </li>
+                            <li class="mdl-list__item mdl-list__item--three-line">
                                 <a class="mdl-list__item-primary-content" href="https://github.com/thevoiceofzeke" target="_blank">
                                     <img class="mdl-list__item-avatar" src="https://github.com/thevoiceofzeke.png?size=200">
                                     <span>Zeke Witter</span>

--- a/contacts.html
+++ b/contacts.html
@@ -136,6 +136,18 @@
                                 </span>
                             </li>
                             <li class="mdl-list__item mdl-list__item--three-line">
+                                <a class="mdl-list__item-primary-content" href="https://github.com/jimhelwig" target="_blank">
+                                    <img class="mdl-list__item-avatar" src="https://github.com/jimhelwig.png?size=200">
+                                    <span>Jim Helwig</span>
+                                    <span class="mdl-list__item-text-body">
+                                        MyUW Product Owner. (UW-Madison DoIT - EIS - Web Platforms / Services - MyUW)
+                                    </span>
+                                </a>
+                                <span class="mdl-list__item-secondary-content">
+                                    <a class="mdl-list__item-secondary-action" href="mailto:jim.helwig@wisc.edu"><i class="material-icons">email</i></a>
+                                </span>
+                            </li>
+                            <li class="mdl-list__item mdl-list__item--three-line">
                                 <a class="mdl-list__item-primary-content" href="https://github.com/thevoiceofzeke" target="_blank">
                                     <img class="mdl-list__item-avatar" src="https://github.com/thevoiceofzeke.png?size=200">
                                     <span>Zeke Witter</span>

--- a/contacts.html
+++ b/contacts.html
@@ -140,7 +140,7 @@
                                     <img class="mdl-list__item-avatar" src="https://github.com/jimhelwig.png?size=200">
                                     <span>Jim Helwig</span>
                                     <span class="mdl-list__item-text-body">
-                                        MyUW Product Owner. (UW-Madison DoIT - EIS - Web Platforms / Services - MyUW)
+                                        MyUW Product Owner. (UW-Madison DoIT - AIS - Web Platforms / Services - MyUW)
                                     </span>
                                 </a>
                                 <span class="mdl-list__item-secondary-content">
@@ -152,7 +152,7 @@
                                     <img class="mdl-list__item-avatar" src="https://github.com/uw-madison-doit.png?size=200">
                                     <span>Annette Statman-Durrer</span>
                                     <span class="mdl-list__item-text-body">
-                                        MyUW Service Team Lead. (UW-Madison DoIT - EIS - Web Platforms / Services - MyUW)
+                                        MyUW Service Team Lead. (UW-Madison DoIT - AIS - Web Platforms / Services - MyUW)
                                     </span>
                                 </a>
                                 <span class="mdl-list__item-secondary-content">

--- a/contacts.html
+++ b/contacts.html
@@ -101,6 +101,11 @@
                     </ul>
                     <p><i>*may require a static vpn connection and/or Shibboleth session to view</i></p>
                     <p>
+                      MyUW Web Components are a product of
+                      <a href="https://it.wisc.edu/services/myuw">
+                        the MyUW service</a>.
+                    </p>
+                    <p>
                         The myuw-web-components project does not have a formal project structure or members with assigned 
                         roles. It is an open source project, always looking for collaborators from within the UW-Madison app development 
                         space and beyond. Here you can find contact information for the foremost contributors to the project.

--- a/contacts.html
+++ b/contacts.html
@@ -106,9 +106,12 @@
                         the MyUW service</a>.
                     </p>
                     <p>
-                        The myuw-web-components project does not have a formal project structure or members with assigned 
-                        roles. It is an open source project, always looking for collaborators from within the UW-Madison app development 
-                        space and beyond. Here you can find contact information for the foremost contributors to the project.
+                        This is
+                        <a href="https://github.com/myuw-web-components/myuw-web-components.github.io/blob/master/LICENSE">
+                          an open source project</a>,
+                        welcoming collaborators from within the UW-Madison app
+                        development space and beyond. Here are some ways to get
+                        get in touch:
                     </p>
                     <div class="list-container">
                         <ul class="mdl-list list-contacts">


### PR DESCRIPTION
+ Clarify that MyUW Web Components are a product of the MyUW service. This may provide a little more reassurance to would-be adopters that there's a service behind this.
+ Add contact information, for the MyUW Developers Google Group, for Jim Helwig as MyUW Product Owner, and for Annette Statman-Durrer as MyUW Service Team Lead.

Before:

<img width="1428" alt="before-no-formal-project-structure" src="https://user-images.githubusercontent.com/952283/53249195-2a4cd100-367d-11e9-816e-8ae156b89e7d.png">

After:

<img width="1215" alt="real-after-its-a-myuw-product-the-name-was-a-hint" src="https://user-images.githubusercontent.com/952283/53249295-5e27f680-367d-11e9-8bbd-c91b52d77f01.png">

