### PR TITLE
Update links to MyUW example to reflect not just in predev

### DIFF
--- a/pages/contacts.html
+++ b/pages/contacts.html
@@ -44,7 +44,7 @@ title: Contacts
         </ul>
       </div>
       <h3>Adopters</h3>
-      <p>You can see myuw-web-components being used on the following sites*:</p>
+      <p>You can see myuw-web-components in use on the following sites*:</p>
       <ul>
         <li><a href="https://kbtest.wisc.edu/kb-site/">KnowledgeBase redesign test site</a></li>
         <li><a href="https://buckybackup.doit.wisc.edu/admin/app/#!/">Bucky Backup admin app</a></li>

--- a/pages/contacts.html
+++ b/pages/contacts.html
@@ -48,7 +48,11 @@ title: Contacts
       <ul>
         <li><a href="https://kbtest.wisc.edu/kb-site/">KnowledgeBase redesign test site</a></li>
         <li><a href="https://buckybackup.doit.wisc.edu/admin/app/#!/">Bucky Backup admin app</a></li>
-        <li><a href="https://predev.my.wisc.edu/">MyUW predev tier</a></li>
+        <li>MyUW:
+          <a href="https://predev.my.wisc.edu/">latest (predev)</a>,
+          <a href="https://my.wisc.edu">production</a>,
+          <a href="https://public.my.wisc.edu">public</a>
+        </li>
       </ul>
       <p><i>*may require a static vpn connection and/or Shibboleth session to view</i></p>
       <h3>All contributors<a href="https://github.com/orgs/myuw-web-components/people" target="_blank"><i


### PR DESCRIPTION
MyUW is now using myuw-web-components in all tiers, not just in predev, so include links to prod and to public.