### PR TITLE
Off-board Zeke: re-cast as a MyUW Infrastructure product

### DIFF
--- a/pages/contacts.html
+++ b/pages/contacts.html
@@ -50,7 +50,7 @@ title: Contacts
         </li>
       </ul>
       <p><i>*may require a static vpn connection and/or Shibboleth session to view</i></p>
-      <h3>All contributors<a href="https://github.com/orgs/myuw-web-components/people" target="_blank"><i
+      <h3>Some contributors<a href="https://github.com/orgs/myuw-web-components/people" target="_blank"><i
             class="material-icons">open_in_new</i></a></h3>
       <div class="grid__contributors">
         <a class="grid__contributors--entry" href="https://github.com/davidmsibley" target="_blank">

--- a/pages/contacts.html
+++ b/pages/contacts.html
@@ -7,24 +7,21 @@ title: Contacts
     <div class="card">
       <h2 id="page-title">Project info &amp; contacts</h2>
       <p>
-        MyUW Web Components is an open source project, always looking for collaborators from within the UW-Madison app
-        development
-        space and beyond. Here you can find contact information for contributors and a list of production sites that use
-        one or more of our components.
+        MyUW Web Components is a product of MyUW Infrastructure.
       </p>
-      <p>Direct feature requests, questions, problems, etc. to the following team members:</p>
+      <p>Direct feature requests, questions, problems, etc. to MyUW Infrastructure:</p>
       <div class="list-container">
         <ul class="mdl-list list-contacts">
           <li class="mdl-list__item mdl-list__item--three-line">
-            <a href="https://github.com/apetro" target="_blank" class="mdl-list__item-primary-content">
-              <img class="mdl-list__item-avatar" src="https://github.com/apetro.png?size=200">
-              <span>Andrew Petro</span>
+            <a href="https://it.wisc.edu/services/myuw" target="_blank" class="mdl-list__item-primary-content">
+              <img class="mdl-list__item-avatar" src="https://github.com/UW-Madison-DoIT.png?size=200">
+              <span>MyUW Infrastructure</span>
               <span class="mdl-list__item-text-body">
-                Frequent contributor, full stack developer for UW-Madison DoIT (AIS-Web Platform Services)
+                Team maintaining MyUW infrastructure, including the my.wisc.edu and my.wisconsin.edu root pages.
               </span>
             </a>
             <span class="mdl-list__item-secondary-content">
-              <a class="mdl-list__item-secondary-action" href="mailto:andrew.petro@wisc.edu"><i
+              <a class="mdl-list__item-secondary-action" href="mailto:myuw-infra@0ffice365.wisc.edu"><i
                   class="material-icons">email</i></a>
             </span>
           </li>

--- a/pages/contacts.html
+++ b/pages/contacts.html
@@ -16,19 +16,6 @@ title: Contacts
       <div class="list-container">
         <ul class="mdl-list list-contacts">
           <li class="mdl-list__item mdl-list__item--three-line">
-            <a class="mdl-list__item-primary-content" href="https://github.com/thevoiceofzeke" target="_blank">
-              <img class="mdl-list__item-avatar" src="https://github.com/thevoiceofzeke.png?size=200">
-              <span>Zeke Witter</span>
-              <span class="mdl-list__item-text-body">
-                Project creator, front-end developer for UW-Madison DoIT (AIS-Web Platform Services)
-              </span>
-            </a>
-            <span class="mdl-list__item-secondary-content">
-              <a class="mdl-list__item-secondary-action" href="mailto:david.witter@wisc.edu"><i
-                  class="material-icons">email</i></a>
-            </span>
-          </li>
-          <li class="mdl-list__item mdl-list__item--three-line">
             <a href="https://github.com/apetro" target="_blank" class="mdl-list__item-primary-content">
               <img class="mdl-list__item-avatar" src="https://github.com/apetro.png?size=200">
               <span>Andrew Petro</span>


### PR DESCRIPTION
Zeke left WPS, so is presumably no longer the go-to contact for MyUW Web Components. So off-boards Zeke from the contacts page.

But weirdly that leaves me as individual human being the go-to contact.

Context: AIS Guiding Principles & Expectations v1 -> Communication -> "Seek team-based communication channels for team-based activities and support."

Most contacts about "feature requests, questions, problems, etc." are team-based activities and support, and so we should seek team-based communication channels for these. So at the least let's run them through the MyUW Infrastructure service rather than through me personally.

So re-casts MyUW Web Components to be a product of MyUW Infrastructure and encourages contact through the MyUW Infrastructure email alias rather than to me personally.

Finally, tweaks the "All contributors" bit to acknowledge that that's "Some contributors".